### PR TITLE
Update import path to mattermost/go-18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Major version changes are documented in the changelog.
 
-To see the documentation for minor or patch version, [view the release notes](https://github.com/nicksnyder/go-i18n/releases).
+To see the documentation for minor or patch version, [view the release notes](https://github.com/mattermost/go-i18n/releases).
 
 ## v2
 
@@ -12,22 +12,22 @@ The first commit to this project was January 2012 (go1 had not yet been released
 This project has evolved with the Go ecosystem since then in a backwards compatible way,
 but there is a growing list of issues and warts that cannot be addressed without breaking compatiblity.
 
-v2 is rewrite of the API from first principals to make it more idiomatic Go, and to resolve a backlog of issues: https://github.com/nicksnyder/go-i18n/milestone/1
+v2 is rewrite of the API from first principals to make it more idiomatic Go, and to resolve a backlog of issues: https://github.com/mattermost/go-i18n/milestone/1
 
 ### Improvements
 
-* Use `golang.org/x/text/language` to get standardized behavior for language matching (https://github.com/nicksnyder/go-i18n/issues/30, https://github.com/nicksnyder/go-i18n/issues/44, https://github.com/nicksnyder/go-i18n/issues/76)
-* Remove global state so that the race detector does not complain when downstream projects run tests that depend on go-i18n in parallel (https://github.com/nicksnyder/go-i18n/issues/82)
-* Automatically extract messages from Go source code (https://github.com/nicksnyder/go-i18n/issues/64)
-* Provide clearer documentation and examples (https://github.com/nicksnyder/go-i18n/issues/27)
-* Reduce complexity of file format for simple translations (https://github.com/nicksnyder/go-i18n/issues/85)
-* Support descriptions for messages (https://github.com/nicksnyder/go-i18n/issues/8)
-* Support custom template delimiters (https://github.com/nicksnyder/go-i18n/issues/88)
+* Use `golang.org/x/text/language` to get standardized behavior for language matching (https://github.com/mattermost/go-i18n/issues/30, https://github.com/mattermost/go-i18n/issues/44, https://github.com/mattermost/go-i18n/issues/76)
+* Remove global state so that the race detector does not complain when downstream projects run tests that depend on go-i18n in parallel (https://github.com/mattermost/go-i18n/issues/82)
+* Automatically extract messages from Go source code (https://github.com/mattermost/go-i18n/issues/64)
+* Provide clearer documentation and examples (https://github.com/mattermost/go-i18n/issues/27)
+* Reduce complexity of file format for simple translations (https://github.com/mattermost/go-i18n/issues/85)
+* Support descriptions for messages (https://github.com/mattermost/go-i18n/issues/8)
+* Support custom template delimiters (https://github.com/mattermost/go-i18n/issues/88)
 
 ### Upgrading from v1
 
 The i18n package in v2 is completely different than v1.
-Refer to the [documentation](https://godoc.org/github.com/nicksnyder/go-i18n/v2/i18n) and [README](https://github.com/nicksnyder/go-i18n/blob/master/README.md) for guidance.
+Refer to the [documentation](https://godoc.org/github.com/mattermost/go-i18n/v2/i18n) and [README](https://github.com/mattermost/go-i18n/blob/master/README.md) for guidance.
 
 The goi18n command has similarities and differences:
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# go-i18n [![Build Status](https://travis-ci.org/nicksnyder/go-i18n.svg?branch=master)](http://travis-ci.org/nicksnyder/go-i18n) [![Report card](https://goreportcard.com/badge/github.com/nicksnyder/go-i18n)](https://goreportcard.com/report/github.com/nicksnyder/go-i18n) [![Sourcegraph](https://sourcegraph.com/github.com/nicksnyder/go-i18n/-/badge.svg)](https://sourcegraph.com/github.com/nicksnyder/go-i18n?badge)
+# go-i18n [![Build Status](https://travis-ci.org/nicksnyder/go-i18n.svg?branch=master)](http://travis-ci.org/nicksnyder/go-i18n) [![Report card](https://goreportcard.com/badge/github.com/mattermost/go-i18n)](https://goreportcard.com/report/github.com/mattermost/go-i18n) [![Sourcegraph](https://sourcegraph.com/github.com/mattermost/go-i18n/-/badge.svg)](https://sourcegraph.com/github.com/mattermost/go-i18n?badge)
 
 go-i18n is a Go [package](#package-i18n) and a [command](#command-goi18n) that helps you translate Go programs into multiple languages.
 
 - Supports [pluralized strings](http://cldr.unicode.org/index/cldr-spec/plural-rules) for all 200+ languages in the [Unicode Common Locale Data Repository (CLDR)](http://www.unicode.org/cldr/charts/28/supplemental/language_plural_rules.html).
-  - Code and tests are [automatically generated](https://github.com/nicksnyder/go-i18n/tree/master/i18n/language/codegen) from [CLDR data](http://cldr.unicode.org/index/downloads).
+  - Code and tests are [automatically generated](https://github.com/mattermost/go-i18n/tree/master/i18n/language/codegen) from [CLDR data](http://cldr.unicode.org/index/downloads).
 - Supports strings with named variables using [text/template](http://golang.org/pkg/text/template/) syntax.
 - Supports message files of any format (e.g. JSON, TOML, YAML, etc.).
-- [Documented](http://godoc.org/github.com/nicksnyder/go-i18n) and [tested](https://travis-ci.org/nicksnyder/go-i18n)!
+- [Documented](http://godoc.org/github.com/mattermost/go-i18n) and [tested](https://travis-ci.org/nicksnyder/go-i18n)!
 
 ## Versions
 
@@ -15,12 +15,12 @@ go-i18n is a Go [package](#package-i18n) and a [command](#command-goi18n) that h
 
 This README always documents the latest version (i.e. v2).
 
-## Package i18n [![GoDoc](http://godoc.org/github.com/nicksnyder/go-i18n?status.svg)](http://godoc.org/github.com/nicksnyder/go-i18n/v2/i18n)
+## Package i18n [![GoDoc](http://godoc.org/github.com/mattermost/go-i18n?status.svg)](http://godoc.org/github.com/mattermost/go-i18n/v2/i18n)
 
 The i18n package provides support for looking up messages according to a set of locale preferences.
 
 ```go
-import "github.com/nicksnyder/go-i18n/v2/i18n"
+import "github.com/mattermost/go-i18n/v2/i18n"
 ```
 
 Create a Bundle to use for the lifetime of your application.
@@ -64,12 +64,12 @@ localizer.MustLocalize(&i18n.LocalizeConfig{
 
 It requires Go 1.9 or newer.
 
-## Command goi18n [![GoDoc](http://godoc.org/github.com/nicksnyder/go-i18n?status.svg)](http://godoc.org/github.com/nicksnyder/go-i18n/v2/goi18n)
+## Command goi18n [![GoDoc](http://godoc.org/github.com/mattermost/go-i18n?status.svg)](http://godoc.org/github.com/mattermost/go-i18n/v2/goi18n)
 
 The goi18n command manages message files used by the i18n package.
 
 ```
-go get -u github.com/nicksnyder/go-i18n/v2/goi18n
+go get -u github.com/mattermost/go-i18n/v2/goi18n
 goi18n -help
 ```
 
@@ -126,9 +126,9 @@ If you have added new messages to your program:
 
 ## For more information and examples:
 
-- Read the [documentation](http://godoc.org/github.com/nicksnyder/go-i18n/v2/i18n).
-- Look at the [code examples](https://github.com/nicksnyder/go-i18n/blob/master/v2/i18n/example_test.go) and [tests](https://github.com/nicksnyder/go-i18n/blob/master/v2/i18n/localizer_test.go).
-- Look at an example [application](https://github.com/nicksnyder/go-i18n/tree/master/v2/example).
+- Read the [documentation](http://godoc.org/github.com/mattermost/go-i18n/v2/i18n).
+- Look at the [code examples](https://github.com/mattermost/go-i18n/blob/master/v2/i18n/example_test.go) and [tests](https://github.com/mattermost/go-i18n/blob/master/v2/i18n/localizer_test.go).
+- Look at an example [application](https://github.com/mattermost/go-i18n/tree/master/v2/example).
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
-module github.com/nicksnyder/go-i18n
+module github.com/mattermost/go-i18n
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pelletier/go-toml v1.2.0
 	gopkg.in/yaml.v2 v2.2.1
 )

--- a/goi18n/constants_command.go
+++ b/goi18n/constants_command.go
@@ -13,9 +13,9 @@ import (
 	"text/template"
 	"unicode"
 
-	"github.com/nicksnyder/go-i18n/i18n/bundle"
-	"github.com/nicksnyder/go-i18n/i18n/language"
-	"github.com/nicksnyder/go-i18n/i18n/translation"
+	"github.com/mattermost/go-i18n/i18n/bundle"
+	"github.com/mattermost/go-i18n/i18n/language"
+	"github.com/mattermost/go-i18n/i18n/translation"
 )
 
 type constantsCommand struct {

--- a/goi18n/doc.go
+++ b/goi18n/doc.go
@@ -1,6 +1,6 @@
 // The goi18n command formats and merges translation files.
 //
-//     go get -u github.com/nicksnyder/go-i18n/goi18n
+//     go get -u github.com/mattermost/go-i18n/goi18n
 //     goi18n -help
 //
 // Help documentation:

--- a/goi18n/gendoc.sh
+++ b/goi18n/gendoc.sh
@@ -1,7 +1,7 @@
 go install
 echo "// The goi18n command formats and merges translation files." > doc.go
 echo "//" >> doc.go
-echo "//     go get -u github.com/nicksnyder/go-i18n/goi18n" >> doc.go
+echo "//     go get -u github.com/mattermost/go-i18n/goi18n" >> doc.go
 echo "//     goi18n -help" >> doc.go
 echo "//" >> doc.go
 echo "// Help documentation:" >> doc.go

--- a/goi18n/merge_command.go
+++ b/goi18n/merge_command.go
@@ -11,9 +11,9 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/nicksnyder/go-i18n/i18n/bundle"
-	"github.com/nicksnyder/go-i18n/i18n/language"
-	"github.com/nicksnyder/go-i18n/i18n/translation"
+	"github.com/mattermost/go-i18n/i18n/bundle"
+	"github.com/mattermost/go-i18n/i18n/language"
+	"github.com/mattermost/go-i18n/i18n/translation"
 	toml "github.com/pelletier/go-toml"
 )
 

--- a/i18n/bundle/bundle.go
+++ b/i18n/bundle/bundle.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"unicode"
 
-	"github.com/nicksnyder/go-i18n/i18n/language"
-	"github.com/nicksnyder/go-i18n/i18n/translation"
+	"github.com/mattermost/go-i18n/i18n/language"
+	"github.com/mattermost/go-i18n/i18n/translation"
 	toml "github.com/pelletier/go-toml"
 	"gopkg.in/yaml.v2"
 )

--- a/i18n/bundle/bundle_test.go
+++ b/i18n/bundle/bundle_test.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/nicksnyder/go-i18n/i18n/language"
-	"github.com/nicksnyder/go-i18n/i18n/translation"
+	"github.com/mattermost/go-i18n/i18n/language"
+	"github.com/mattermost/go-i18n/i18n/translation"
 )
 
 func TestMustLoadTranslationFile(t *testing.T) {

--- a/i18n/example_test.go
+++ b/i18n/example_test.go
@@ -3,7 +3,7 @@ package i18n_test
 import (
 	"fmt"
 
-	"github.com/nicksnyder/go-i18n/i18n"
+	"github.com/mattermost/go-i18n/i18n"
 )
 
 func Example() {

--- a/i18n/exampletemplate_test.go
+++ b/i18n/exampletemplate_test.go
@@ -1,7 +1,7 @@
 package i18n_test
 
 import (
-	"github.com/nicksnyder/go-i18n/i18n"
+	"github.com/mattermost/go-i18n/i18n"
 	"os"
 	"text/template"
 )

--- a/i18n/exampleyaml_test.go
+++ b/i18n/exampleyaml_test.go
@@ -3,7 +3,7 @@ package i18n_test
 import (
 	"fmt"
 
-	"github.com/nicksnyder/go-i18n/i18n"
+	"github.com/mattermost/go-i18n/i18n"
 )
 
 func Example_yaml() {

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -56,9 +56,9 @@
 package i18n
 
 import (
-	"github.com/nicksnyder/go-i18n/i18n/bundle"
-	"github.com/nicksnyder/go-i18n/i18n/language"
-	"github.com/nicksnyder/go-i18n/i18n/translation"
+	"github.com/mattermost/go-i18n/i18n/bundle"
+	"github.com/mattermost/go-i18n/i18n/language"
+	"github.com/mattermost/go-i18n/i18n/translation"
 )
 
 // TranslateFunc returns the translation of the string identified by translationID.

--- a/i18n/translation/plural_translation.go
+++ b/i18n/translation/plural_translation.go
@@ -1,7 +1,7 @@
 package translation
 
 import (
-	"github.com/nicksnyder/go-i18n/i18n/language"
+	"github.com/mattermost/go-i18n/i18n/language"
 )
 
 type pluralTranslation struct {

--- a/i18n/translation/plural_translation_test.go
+++ b/i18n/translation/plural_translation_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/nicksnyder/go-i18n/i18n/language"
+	"github.com/mattermost/go-i18n/i18n/language"
 )
 
 func mustTemplate(t *testing.T, src string) *template {

--- a/i18n/translation/single_translation.go
+++ b/i18n/translation/single_translation.go
@@ -1,7 +1,7 @@
 package translation
 
 import (
-	"github.com/nicksnyder/go-i18n/i18n/language"
+	"github.com/mattermost/go-i18n/i18n/language"
 )
 
 type singleTranslation struct {

--- a/i18n/translation/translation.go
+++ b/i18n/translation/translation.go
@@ -4,7 +4,7 @@ package translation
 import (
 	"fmt"
 
-	"github.com/nicksnyder/go-i18n/i18n/language"
+	"github.com/mattermost/go-i18n/i18n/language"
 )
 
 // Translation is the interface that represents a translated string.

--- a/i18n/translations_test.go
+++ b/i18n/translations_test.go
@@ -3,7 +3,7 @@ package i18n
 import (
 	"testing"
 
-	"github.com/nicksnyder/go-i18n/i18n/bundle"
+	"github.com/mattermost/go-i18n/i18n/bundle"
 )
 
 var bobMap = map[string]interface{}{"Person": "Bob"}

--- a/v2/example/main.go
+++ b/v2/example/main.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 
 	"github.com/BurntSushi/toml"
-	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"github.com/mattermost/go-i18n/v2/i18n"
 	"golang.org/x/text/language"
 )
 

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,4 +1,4 @@
-module github.com/nicksnyder/go-i18n/v2
+module github.com/mattermost/go-i18n/v2
 
 require (
 	github.com/BurntSushi/toml v0.3.0

--- a/v2/goi18n/extract_command.go
+++ b/v2/goi18n/extract_command.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/nicksnyder/go-i18n/v2/i18n"
-	"github.com/nicksnyder/go-i18n/v2/internal"
+	"github.com/mattermost/go-i18n/v2/i18n"
+	"github.com/mattermost/go-i18n/v2/internal"
 )
 
 func usageExtract() {
@@ -210,7 +210,7 @@ func extractStringLiteral(expr ast.Expr) (string, bool) {
 
 func i18nPackageName(file *ast.File) string {
 	for _, i := range file.Imports {
-		if i.Path.Kind == token.STRING && i.Path.Value == `"github.com/nicksnyder/go-i18n/v2/i18n"` {
+		if i.Path.Kind == token.STRING && i.Path.Value == `"github.com/mattermost/go-i18n/v2/i18n"` {
 			if i.Name == nil {
 				return "i18n"
 			}

--- a/v2/goi18n/extract_command_test.go
+++ b/v2/goi18n/extract_command_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"github.com/mattermost/go-i18n/v2/i18n"
 )
 
 func TestExtract(t *testing.T) {
@@ -29,7 +29,7 @@ func TestExtract(t *testing.T) {
 			name: "global declaration",
 			file: `package main
 
-			import "github.com/nicksnyder/go-i18n/v2/i18n"
+			import "github.com/mattermost/go-i18n/v2/i18n"
 
 			var m = &i18n.Message{
 				ID: "Plural ID",
@@ -45,7 +45,7 @@ func TestExtract(t *testing.T) {
 			name: "short form id only",
 			file: `package main
 
-			import "github.com/nicksnyder/go-i18n/v2/i18n"
+			import "github.com/mattermost/go-i18n/v2/i18n"
 
 			func main() {
 				bundle := &i18n.Bundle{}
@@ -63,7 +63,7 @@ func TestExtract(t *testing.T) {
 			name: "must short form id only",
 			file: `package main
 
-			import "github.com/nicksnyder/go-i18n/v2/i18n"
+			import "github.com/mattermost/go-i18n/v2/i18n"
 
 			func main() {
 				bundle := &i18n.Bundle{}
@@ -81,7 +81,7 @@ func TestExtract(t *testing.T) {
 			name: "custom package name",
 			file: `package main
 
-			import bar "github.com/nicksnyder/go-i18n/v2/i18n"
+			import bar "github.com/mattermost/go-i18n/v2/i18n"
 
 			func main() {
 				_ := &bar.Message{
@@ -99,7 +99,7 @@ func TestExtract(t *testing.T) {
 			name: "exhaustive plural translation",
 			file: `package main
 
-			import "github.com/nicksnyder/go-i18n/v2/i18n"
+			import "github.com/mattermost/go-i18n/v2/i18n"
 
 			func main() {
 				_ := &i18n.Message{
@@ -140,7 +140,7 @@ zero = "Zero translation"
 			name: "concat id",
 			file: `package main
 
-			import "github.com/nicksnyder/go-i18n/v2/i18n"
+			import "github.com/mattermost/go-i18n/v2/i18n"
 
 			func main() {
 				_ := &i18n.Message{

--- a/v2/goi18n/main.go
+++ b/v2/goi18n/main.go
@@ -1,6 +1,6 @@
 // Command goi18n manages message files used by the i18n package.
 //
-//     go get -u github.com/nicksnyder/go-i18n/v2/goi18n
+//     go get -u github.com/mattermost/go-i18n/v2/goi18n
 //     goi18n -help
 //
 // Use `goi18n extract` to create a message file that contains the messages defined in your Go source files.

--- a/v2/goi18n/marshal.go
+++ b/v2/goi18n/marshal.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
-	"github.com/nicksnyder/go-i18n/v2/internal"
-	"github.com/nicksnyder/go-i18n/v2/internal/plural"
+	"github.com/mattermost/go-i18n/v2/internal"
+	"github.com/mattermost/go-i18n/v2/internal/plural"
 	"golang.org/x/text/language"
 	yaml "gopkg.in/yaml.v2"
 )

--- a/v2/goi18n/merge_command.go
+++ b/v2/goi18n/merge_command.go
@@ -10,9 +10,9 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
-	"github.com/nicksnyder/go-i18n/v2/i18n"
-	"github.com/nicksnyder/go-i18n/v2/internal"
-	"github.com/nicksnyder/go-i18n/v2/internal/plural"
+	"github.com/mattermost/go-i18n/v2/i18n"
+	"github.com/mattermost/go-i18n/v2/internal"
+	"github.com/mattermost/go-i18n/v2/internal/plural"
 	"golang.org/x/text/language"
 	yaml "gopkg.in/yaml.v2"
 )

--- a/v2/i18n/bundle.go
+++ b/v2/i18n/bundle.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/nicksnyder/go-i18n/v2/internal"
-	"github.com/nicksnyder/go-i18n/v2/internal/plural"
+	"github.com/mattermost/go-i18n/v2/internal"
+	"github.com/mattermost/go-i18n/v2/internal/plural"
 
 	"golang.org/x/text/language"
 )

--- a/v2/i18n/bundle_test.go
+++ b/v2/i18n/bundle_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
-	"github.com/nicksnyder/go-i18n/v2/internal"
+	"github.com/mattermost/go-i18n/v2/internal"
 	"golang.org/x/text/language"
 	yaml "gopkg.in/yaml.v2"
 )

--- a/v2/i18n/example_test.go
+++ b/v2/i18n/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/BurntSushi/toml"
-	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"github.com/mattermost/go-i18n/v2/i18n"
 	"golang.org/x/text/language"
 )
 

--- a/v2/i18n/localizer.go
+++ b/v2/i18n/localizer.go
@@ -5,8 +5,8 @@ import (
 
 	"text/template"
 
-	"github.com/nicksnyder/go-i18n/v2/internal"
-	"github.com/nicksnyder/go-i18n/v2/internal/plural"
+	"github.com/mattermost/go-i18n/v2/internal"
+	"github.com/mattermost/go-i18n/v2/internal/plural"
 	"golang.org/x/text/language"
 )
 

--- a/v2/i18n/message.go
+++ b/v2/i18n/message.go
@@ -1,6 +1,6 @@
 package i18n
 
-import "github.com/nicksnyder/go-i18n/v2/internal"
+import "github.com/mattermost/go-i18n/v2/internal"
 
 // Message is a string that can be localized.
 type Message = internal.Message

--- a/v2/internal/message_template.go
+++ b/v2/internal/message_template.go
@@ -6,7 +6,7 @@ import (
 
 	"text/template"
 
-	"github.com/nicksnyder/go-i18n/v2/internal/plural"
+	"github.com/mattermost/go-i18n/v2/internal/plural"
 )
 
 // MessageTemplate is an executable template for a message.

--- a/v2/internal/message_template_test.go
+++ b/v2/internal/message_template_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/nicksnyder/go-i18n/v2/internal/plural"
+	"github.com/mattermost/go-i18n/v2/internal/plural"
 )
 
 func TestMessageTemplate(t *testing.T) {


### PR DESCRIPTION
This change modifies all paths referenced as 'nicksnyder/go-i18n'
to 'mattermost/go-18n'. This allows for proper usage as a go
module.